### PR TITLE
Add circular ref workaroud option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A GitHub Action to compare two OpenAPI specifications and detect breaking change
 | `fail-on-changed` | No | `false` | Fail if any changes detected |
 | `headers` | No | - | HTTP headers for fetching remote URL specs (format: `Header=Value,Header2=Value2`) |
 | `log-level` | No | `ERROR` | Log level (TRACE, DEBUG, INFO, WARN, ERROR, OFF) |
+| `circular-ref-mode` | No | `replace-allof` | Circular reference handling: `replace-allof` or `flatten` |
 | `add-pr-comment` | No | `false` | Post results as PR comment (updates existing comment if present) |
 | `github-token` | No | - | Token for PR comments (required if `add-pr-comment` is true) |
 | `artifact-name` | No | `openapi-diff-report` | Name for the uploaded artifact containing report files |
@@ -222,7 +223,16 @@ If using the action multiple times in the same workflow, specify unique artifact
 
 ### Circular Reference Handling
 
-This action automatically flattens OpenAPI specifications using [oasdiff](https://github.com/oasdiff/oasdiff) before comparison. This resolves circular `$ref` references that would otherwise cause `StackOverflowError` in the underlying openapi-diff tool (see [issue #124](https://github.com/OpenAPITools/openapi-diff/issues/124)).
+Specs with circular `$ref` cause `StackOverflowError` in openapi-diff ([issue #124](https://github.com/OpenAPITools/openapi-diff/issues/124)). This action provides two handling modes:
+
+**`replace-allof` (default)**: Replaces `"allOf"` with `"oneOf"` using sed. Works around the bug since openapi-diff handles `oneOf` circular refs correctly but not `allOf`.
+
+**`flatten`**: Uses `oasdiff flatten`.
+
+Example using flatten mode:
+```yaml
+circular-ref-mode: 'flatten'
+```
 
 ### Output Format
 

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,10 @@ inputs:
     description: 'Log level (TRACE, DEBUG, INFO, WARN, ERROR, OFF)'
     required: false
     default: 'ERROR'
+  circular-ref-mode:
+    description: 'How to handle circular references: "replace-allof" (sed-based, deterministic, default) or "flatten" (oasdiff-based, may be non-deterministic)'
+    required: false
+    default: 'replace-allof'
   add-pr-comment:
     description: 'Add diff results as a PR comment'
     required: false
@@ -91,6 +95,7 @@ runs:
         INPUT_FAIL_ON_CHANGED: ${{ inputs.fail-on-changed }}
         INPUT_HEADERS: ${{ inputs.headers }}
         INPUT_LOG_LEVEL: ${{ inputs.log-level }}
+        INPUT_CIRCULAR_REF_MODE: ${{ inputs.circular-ref-mode }}
       run: ${{ github.action_path }}/scripts/run-diff.sh
 
     - name: Get PR number

--- a/test/specs/circular-ref-v1.yaml
+++ b/test/specs/circular-ref-v1.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Circular Reference Test API
+  version: 1.0.0
+
+paths:
+  /items:
+    get:
+      summary: Get items
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BaseItem'
+
+components:
+  schemas:
+    BaseItem:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        parent:
+          allOf:
+            - $ref: '#/components/schemas/BaseItem'
+          nullable: true
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/BaseItem'

--- a/test/specs/circular-ref-v2.yaml
+++ b/test/specs/circular-ref-v2.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+info:
+  title: Circular Reference Test API
+  version: 2.0.0
+
+paths:
+  /items:
+    get:
+      summary: Get items
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BaseItem'
+  /items/{id}:
+    get:
+      summary: Get item by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseItem'
+
+components:
+  schemas:
+    BaseItem:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        parent:
+          allOf:
+            - $ref: '#/components/schemas/BaseItem'
+          nullable: true
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/BaseItem'


### PR DESCRIPTION
Because of a bug with oasdiff(at least similar to this https://github.com/oasdiff/oasdiff/issues/767) flattening causing non-determanistic outputs reproduced like this: 

```
#download jellyfin openapi spec
$ oasdiff flatten openapi-base.json --format json > ./test1.json
$ oasdiff flatten openapi-base.json --format json > ./test2.json
$ diff <(jq -S . test1.json) <(jq -S . test2.json)
1603c1603
<                         "nullable": true
---
>                         "type": "string"
1654c1654
<                         "nullable": true
---
>                         "type": "string"
1687c1687
<                         "nullable": true
---
>                         "type": "string"
1802c1802
<                         "nullable": true
---
...
```

this PR adds an option to use the Workaround mentioned in https://github.com/OpenAPITools/openapi-diff/issues/124 of just replacing allOf with oneOf (this used to also be done by jellyfin)